### PR TITLE
feat: add explosion animation on defeat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,6 +489,7 @@ checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 name = "enimdnal"
 version = "0.1.0"
 dependencies = [
+ "itertools",
  "notan",
 ]
 
@@ -968,6 +969,15 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,5 @@ edition = "2021"
 
 [dependencies]
 
+itertools = "0.10"
 notan = "0.9"

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,4 +1,4 @@
-mod defeat;
+pub(crate) mod defeat;
 mod paused;
 mod playing;
 mod victory;
@@ -9,12 +9,14 @@ use notan::prelude::*;
 use crate::drawing::TILE_SIZE;
 use crate::minefield::Board;
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+use defeat::DefeatState;
+
+#[derive(Debug)]
 pub enum Stage {
     Playing,
     Paused,
     Victory,
-    Defeat,
+    Defeat(DefeatState),
 }
 
 #[derive(AppState)]
@@ -57,8 +59,8 @@ impl State {
         Some((board_x, board_y))
     }
 
-    pub fn stage(&self) -> Stage {
-        self.stage
+    pub fn stage(&self) -> &Stage {
+        &self.stage
     }
 
     pub fn board(&self) -> &Board {
@@ -96,10 +98,13 @@ pub fn setup(gfx: &mut Graphics) -> State {
 }
 
 pub fn update(app: &mut App, state: &mut State) {
-    match state.stage {
+    match &mut state.stage {
         Stage::Playing => playing::update(app, state),
         Stage::Paused => paused::update(app, state),
-        Stage::Defeat => defeat::update(app, state),
+        Stage::Defeat(defeat_state) => {
+            defeat_state.update(app);
+            defeat::update(app, state);
+        }
         Stage::Victory => victory::update(app, state),
     }
 }

--- a/src/state/defeat.rs
+++ b/src/state/defeat.rs
@@ -2,6 +2,25 @@ use notan::prelude::*;
 
 use crate::state::{Stage, State};
 
+#[derive(Debug)]
+pub struct Explosion {
+    pub pos: (usize, usize),
+    pub delay: u32,
+}
+
+#[derive(Debug)]
+pub struct DefeatState {
+    pub explosions: Vec<Explosion>,
+    pub elapsed_milisec: u32,
+}
+
+impl DefeatState {
+    pub fn update(&mut self, app: &App) {
+        let delta = app.timer.delta().subsec_millis();
+        self.elapsed_milisec += delta;
+    }
+}
+
 pub fn update(app: &mut App, state: &mut State) {
     state.hover = None;
 

--- a/src/state/playing.rs
+++ b/src/state/playing.rs
@@ -1,5 +1,7 @@
+use itertools::Itertools;
 use notan::prelude::*;
 
+use crate::state::defeat::{DefeatState, Explosion};
 use crate::state::{Stage, State};
 
 pub fn update(app: &mut App, state: &mut State) {
@@ -22,7 +24,9 @@ pub fn update(app: &mut App, state: &mut State) {
     }
 
     if state.board.is_defeat() {
-        state.stage = Stage::Defeat;
+        let triggered_pos = board_coords
+            .expect("Failed to obtain board coords when transitioning playing -> defeat");
+        transition_defeat(state, triggered_pos);
     } else if state.board.is_victory() {
         state.stage = Stage::Victory;
     }
@@ -30,4 +34,53 @@ pub fn update(app: &mut App, state: &mut State) {
     if app.keyboard.was_pressed(KeyCode::Return) {
         state.stage = Stage::Paused;
     }
+}
+
+fn transition_defeat(state: &mut State, triggered_pos: (usize, usize)) {
+    const EXPLOSION_RING_DELAY: u32 = 80;
+
+    let (width, height) = state.board().dims();
+    let mut explosions = vec![];
+
+    for y in 0..height {
+        for x in 0..width {
+            let tile = state.board().tile(x, y);
+
+            if !tile.is_mine() {
+                continue;
+            }
+
+            let explosion = Explosion {
+                pos: (x, y),
+                delay: 0,
+            };
+            explosions.push(explosion);
+        }
+    }
+
+    explosions.sort_by_key(|expl| distance(triggered_pos, expl.pos));
+
+    let rings = explosions
+        .iter_mut()
+        .group_by(|expl| distance(triggered_pos, expl.pos));
+    let mut current_delay = 0;
+    for (_, ring) in &rings {
+        for expl in ring {
+            expl.delay = current_delay;
+        }
+
+        current_delay += EXPLOSION_RING_DELAY;
+    }
+
+    state.stage = Stage::Defeat(DefeatState {
+        explosions,
+        elapsed_milisec: 0,
+    });
+}
+
+fn distance((from_x, from_y): (usize, usize), (p_x, p_y): (usize, usize)) -> usize {
+    let x_projection = usize::abs_diff(from_x, p_x);
+    let y_projection = usize::abs_diff(from_y, p_y);
+
+    std::cmp::max(x_projection, y_projection)
 }


### PR DESCRIPTION
Add explosion shock wave animation on defeat:

![boom](https://github.com/enimdnal/enimdnal/assets/5671049/3ef4c496-452a-4b2e-a905-dd5b288d9814)
